### PR TITLE
Fix wheel support checks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .cache/
 .tox/
 .mypy_cache
+__pycache__/

--- a/src/dotlock/dist_info/wheel_filename_parsing.py
+++ b/src/dotlock/dist_info/wheel_filename_parsing.py
@@ -49,7 +49,8 @@ def get_supported(version, platform, impl, abi, manylinux1, noarch=False):
             else:
                 # arch pattern didn't match (?!)
                 arches = [arch]
-        elif platform is None and manylinux1:
+        # DIFFERS FROM ORIGINAL: support manylinux1 even if platform is specified.
+        elif manylinux1:
             arches = [arch.replace('linux', 'manylinux1'), arch]
         else:
             arches = [arch]

--- a/src/dotlock/env.py
+++ b/src/dotlock/env.py
@@ -6,7 +6,7 @@ from typing import Dict
 from packaging.markers import default_environment
 
 from dotlock._vendored.pep425tags import (
-    get_impl_tag, get_abi_tag, get_platform, is_manylinux1_compatible, get_impl_version_info,
+    get_abbr_impl, get_abi_tag, get_platform, is_manylinux1_compatible, get_impl_version_info,
 )
 
 
@@ -19,7 +19,7 @@ pep425tags: Dict[str, str] = {}
 
 def default_pep425tags():
     return {
-        'impl': get_impl_tag(),
+        'impl': get_abbr_impl(),
         'abi': get_abi_tag(),
         'platform': get_platform(),
         'manylinux1': is_manylinux1_compatible(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,6 @@ import pytest
 from dotlock.tempdir import temp_working_dir
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--numpy", action="store_true", help="Run numpy tests (slow)."
-    )
-
-
 @pytest.fixture(name='tempdir')
 def tempdir_fixture():
     with temp_working_dir('test'):

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -25,16 +25,14 @@ def make_package_json(source, name, spec):
 @pytest.mark.parametrize('source,name,spec,version', [
     ('https://pypi.org/pypi', 'requests', '==2.18.4', '2.18.4'),
     ('https://pypi.org/pypi', 'numpy', '==1.15.3', '1.15.3'),
-    ('https://pypi.org/simple', 'requests','==2.18.3', '2.18.3'),
+    ('https://pypi.org/pypi', 'matplotlib', '==3.0.2', '3.0.2'),
+    ('https://pypi.org/simple', 'requests', '==2.18.3', '2.18.3'),
     ('https://pypi.org/pypi', 'requests', 'git+git://github.com/requests/requests@v2.19.1', '2.19.1'),
     ('https://pypi.org/pypi', 'requests', 'svn+https://github.com/requests/requests/trunk@6920', '2.19.0'),
     ('https://pypi.org/pypi', 'distlib', 'hg+https://hg.python.org/distlib@0.1.7', '0.1.7'),
     ('https://pypi.org/pypi', 'fakepkg', str(test_path / 'fakepkg'), '1.2.3'),
 ])
 def test_package(source, name, spec, version, tempdir, request):
-    if name == 'numpy' and not request.config.getoption('numpy'):
-        pytest.skip('Skipping numpy test because it is so slow.')
-
     make_package_json(source, name, spec)
 
     # Use --update to bypass the cache.

--- a/tests/integration/test_resolution.py
+++ b/tests/integration/test_resolution.py
@@ -46,39 +46,43 @@ async def test_certbot():
         update=False,
     )
     candidates = resolve.candidate_topo_sort(requirements)
-    candidate_names = [candidate.info.name for candidate in candidates]
 
+    certbot = candidates[-1].info
+    assert certbot.name == 'certbot'
+    assert certbot.package_type == resolve.PackageType.bdist_wheel
+
+    candidate_names = [candidate.info.name for candidate in candidates]
     assert candidate_names == [
-        'setuptools',
-        'zope-interface',
-        'zope-hookable',
-        'zope-event',
-        'zope-deprecation',
-        'zope-proxy',
-        'zope-deferredimport',
-        'zope-component',
-        'pytz',
-        'pyrfc3339',
-        'future',
-        'parsedatetime',
-        'pbr',
-        'six',
-        'mock',
         'idna',
         'asn1crypto',
+        'six',
         'pycparser',
         'cffi',
         'cryptography',
         'pyopenssl',
+        'setuptools',
         'josepy',
-        'configobj',
-        'configargparse',
-        'certifi',
-        'urllib3',
+        'pbr',
+        'mock',
+        'pytz',
+        'pyrfc3339',
         'chardet',
+        'urllib3',
+        'certifi',
         'requests',
         'requests-toolbelt',
         'acme',
+        'configargparse',
+        'configobj',
+        'future',
+        'parsedatetime',
+        'zope-interface',
+        'zope-proxy',
+        'zope-deferredimport',
+        'zope-deprecation',
+        'zope-event',
+        'zope-hookable',
+        'zope-component',
         'certbot',
     ]
 

--- a/tests/unit/test_wheel_filename_parsing.py
+++ b/tests/unit/test_wheel_filename_parsing.py
@@ -1,0 +1,28 @@
+import pytest
+
+from dotlock.dist_info import wheel_filename_parsing
+
+
+@pytest.mark.parametrize(
+    ('wheel', 'supported'), [
+        ('matplotlib-3.0.2-cp37-cp37m-manylinux1_x86_64.whl', True),
+        ('matplotlib-3.0.2-cp36-cp36m-manylinux1_x86_64.whl', False),
+        ('matplotlib-3.0.2-cp27-cp27m-manylinux1_x86_64.whl', False),
+        ('matplotlib-3.0.2-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl', False),
+        ('matplotlib-3.0.2-pp35-pypy_41-manylinux1_x86_64.whl', False),
+        ('matplotlib-3.0.2-cp37-cp37m-win32.whl', False),
+        ('matplotlib-3.0.2-py3-none-any.whl', True),
+        ('matplotlib-3.0.2-py2-none-any.whl', False),
+        ('matplotlib-3.0.2-py2.py3-none-any.whl', True),
+    ]
+)
+def test_is_supported_cp37_manylinux1_x86_64(monkeypatch, wheel, supported):
+    monkeypatch.setattr(wheel_filename_parsing, 'pep425tags', {
+        'abi': 'cp37m',
+        'impl': 'cp',
+        'manylinux1': True,
+        'platform': 'linux_x86_64',
+        'version': '3.7'
+    })
+
+    assert wheel_filename_parsing.is_supported(wheel) is supported


### PR DESCRIPTION
Fixes a bug where the wrong implementation tag was used to check wheel
support, resulting in many wheels being erroneously rejected. In
particular, numpy and matplotlib wheels can now be selected.